### PR TITLE
Quick open files via "right" key doesn't seem to work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 File History Changelog
 ======================
 
+v1.4.7 (2014-07-07)
+-------------------
+
+- Fix for issue #16 due to which "right" key shortcut to open file was broken
+
 v1.4.6 (2014-01-23)
 -------------------
 

--- a/messages.json
+++ b/messages.json
@@ -1,4 +1,4 @@
 {
     "install": "messages/install.txt",
-    "1.4.6": "CHANGELOG.md"
+    "1.4.7": "CHANGELOG.md"
 }


### PR DESCRIPTION
When I try to open the currently previewed file using the `right` key, it works the first time, but when I try to open additional files, it doesn't do anything. This is on ST3.
