### PR TITLE
Fix quick_open_file_history, among other things

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,5 +1,5 @@
 [
-    { "keys": ["ctrl+shift+t"],     "command": "open_recently_closed_file", "args": {"show_quick_panel": false} },
+    { "keys": ["ctrl+shift+t"],     "command": "open_recently_closed_file", "args": {"action": "open_latest_closed"} },
     { "keys": ["ctrl+alt+t"],       "command": "open_recently_closed_file" },
     { "keys": ["ctrl+alt+shift+t"], "command": "open_recently_closed_file", "args": {"current_project_only": false} },
     { "keys": ["right"], "command": "quick_open_file_history", "context": [

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,5 +1,5 @@
 [
-    { "keys": ["super+shift+t"],     "command": "open_recently_closed_file", "args": {"show_quick_panel": false} },
+    { "keys": ["super+shift+t"],     "command": "open_recently_closed_file", "args": {"action": "open_latest_closed"} },
     { "keys": ["super+alt+t"],       "command": "open_recently_closed_file" },
     { "keys": ["super+alt+shift+t"], "command": "open_recently_closed_file", "args": {"current_project_only": false} },
     { "keys": ["right"], "command": "quick_open_file_history", "context": [

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,5 +1,5 @@
 [
-    { "keys": ["ctrl+shift+t"],     "command": "open_recently_closed_file", "args": {"show_quick_panel": false} },
+    { "keys": ["ctrl+shift+t"],     "command": "open_recently_closed_file", "args": {"action": "open_latest_closed"} },
     { "keys": ["ctrl+alt+t"],       "command": "open_recently_closed_file" },
     { "keys": ["ctrl+alt+shift+t"], "command": "open_recently_closed_file", "args": {"current_project_only": false} },
     { "keys": ["right"], "command": "quick_open_file_history", "context": [

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ For this, add a `"file_history"` dictionary to your project's settings and then 
 
 **open_recently_closed_file** (Window)
 
-Opens a popup with recently closed files or reopens the lastly closed view if `show_quick_panel == False`.
+Opens a popup with recently closed files or reopens the lastly closed view if `action == "open_latest_closed"`.
 
 >   *Parameters*
 
->   - **show_quick_panel** (bool) - *Default*: `True`
+>   - **action** (str) - *Default*: `"show_history"`, *Allowed values*: `"show_history"`, `"open_latest_closed"`
 
 >   - **current_project_only** (bool) - *Default*: `True`
 

--- a/file_history.py
+++ b/file_history.py
@@ -411,8 +411,6 @@ class FileHistory(with_metaclass(Singleton)):
         self.current_history_entry = None
         self.current_selected_index = -1
 
-        self.project_name = None
-
     def __track_calling_view(self, window):
         """Remember the view that the command was run from (including the group and index positions),
         so we can return to the "calling" view if the user cancels the preview

--- a/file_history.py
+++ b/file_history.py
@@ -409,7 +409,6 @@ class FileHistory(with_metaclass(Singleton)):
 
         self.current_view = None
         self.current_history_entry = None
-        self.current_selected_index = -1
 
     def __track_calling_view(self, window):
         """Remember the view that the command was run from (including the group and index positions),
@@ -449,8 +448,6 @@ class FileHistory(with_metaclass(Singleton)):
 
     def preview_history(self, window, selected_index, history_entry):
         """Preview the file if it exists, otherwise show the previous view (aka the "calling_view")"""
-        # Save the selected index for a potential reopen when an entry is deleted
-        self.current_selected_index = selected_index
         self.current_history_entry = history_entry
 
         # track the view even if we won't be previewing it (to support quick-open and remove from history quick keys)
@@ -583,14 +580,9 @@ class DeleteFileHistoryEntryCommand(sublime_plugin.WindowCommand):
     def run(self):
         FileHistory().delete_current_entry()
 
-        # Remember if we are showing the global history or the project-specific history
-        project_flag = not (FileHistory().project_name == 'global')
-
         # Deleting an entry from the quick panel should reopen it with the entry removed
         # TODO recover filter text? (I don't think it is possible to get the quick-panel filter text from the API)
-        args = {'current_project_only': project_flag,
-                'selected_index': FileHistory().current_selected_index}
-        sublime.active_window().run_command('hide_overlay')
+        args = {'refresh_quick_panel': True}
         sublime.active_window().run_command('open_recently_closed_file', args=args)
 
 
@@ -651,7 +643,13 @@ class OpenRecentlyClosedFileCommand(sublime_plugin.WindowCommand):
         if index <= len(self.history_list[key]):
             return self.history_list[key][index]
 
-    def run(self, show_quick_panel=True, current_project_only=True, selected_index=-1):
+    def run(self, show_quick_panel=True, refresh_quick_panel=False, current_project_only=True, selected_index=-1):
+        if refresh_quick_panel and self.__class__.is_active():
+            self.refresh_in_progress = True
+            sublime.active_window().run_command('hide_overlay')
+            return
+
+        self.current_project_only = current_project_only
         self.history_list = FileHistory().get_history(current_project_only)
         if show_quick_panel:
             # Prepare the display list with the file name and path separated
@@ -738,6 +736,11 @@ class OpenRecentlyClosedFileCommand(sublime_plugin.WindowCommand):
             FileHistory().reset(self.window)
 
         self.history_list = {}
+
+        if self.refresh_in_progress:
+            self.refresh_in_progress = False
+            args = {'current_project_only': self.current_project_only}
+            sublime.active_window().run_command('open_recently_closed_file', args=args)
 
 
 class OpenRecentlyCloseFileCommandContextHandler(sublime_plugin.EventListener):

--- a/file_history.py
+++ b/file_history.py
@@ -446,7 +446,7 @@ class FileHistory(with_metaclass(Singleton)):
             index = 0
         return (group, index)
 
-    def preview_history(self, window, selected_index, history_entry):
+    def preview_history(self, window, history_entry):
         """Preview the file if it exists, otherwise show the previous view (aka the "calling_view")"""
         self.current_history_entry = history_entry
 
@@ -582,7 +582,7 @@ class DeleteFileHistoryEntryCommand(sublime_plugin.WindowCommand):
 
         # Deleting an entry from the quick panel should reopen it with the entry removed
         # TODO recover filter text? (I don't think it is possible to get the quick-panel filter text from the API)
-        args = {'refresh_quick_panel': True}
+        args = {'action': "delete_current_entry"}
         sublime.active_window().run_command('open_recently_closed_file', args=args)
 
 
@@ -630,6 +630,29 @@ class OpenRecentlyClosedFileCommand(sublime_plugin.WindowCommand):
 
         return ", ".join(magnitudes)
 
+    def set_refresh_in_progress(self):
+        self.refresh_in_progress = True
+
+    def clear_refresh_in_progress(self):
+        del self.refresh_in_progress
+
+    def is_refresh_in_progress(self):
+        return hasattr(self, "refresh_in_progress")
+
+    def delete_current_entry(self):
+        if not self.current_selected_index or self.current_selected_index < 0:
+            return
+
+        closed_len = len(self.history_list['closed'])
+        if self.current_selected_index < closed_len:
+            key = 'closed'
+        else:
+            self.current_selected_index -= closed_len
+            key = 'opened'
+
+        if self.current_selected_index <= len(self.history_list[key]):
+            del self.history_list[key][self.current_selected_index]
+
     def get_history_by_index(self, index):
         if index < 0:
             return
@@ -643,15 +666,19 @@ class OpenRecentlyClosedFileCommand(sublime_plugin.WindowCommand):
         if index <= len(self.history_list[key]):
             return self.history_list[key][index]
 
-    def run(self, show_quick_panel=True, refresh_quick_panel=False, current_project_only=True, selected_index=-1):
-        if refresh_quick_panel and self.__class__.is_active():
-            self.refresh_in_progress = True
-            sublime.active_window().run_command('hide_overlay')
-            return
+    def run(self, current_project_only=True, action="show_history"):
 
-        self.current_project_only = current_project_only
-        self.history_list = FileHistory().get_history(current_project_only)
-        if show_quick_panel:
+        if action == "show_history":
+            self.current_project_only = current_project_only
+
+            if not self.is_refresh_in_progress():
+                self.history_list = FileHistory().get_history(current_project_only)
+                self.current_selected_index = None
+                selected_index = 0
+            else:
+                self.clear_refresh_in_progress()
+                selected_index = self.current_selected_index
+
             # Prepare the display list with the file name and path separated
             display_list = []
             for key in ('closed', 'opened'):
@@ -674,6 +701,10 @@ class OpenRecentlyClosedFileCommand(sublime_plugin.WindowCommand):
                         info.append((' ' * 6) + stamp)
 
                     display_list.append(info)
+
+            if not display_list:
+                return
+
             font_flag = sublime.MONOSPACE_FONT if FileHistory().USE_MONOSPACE else 0
 
             self.__class__.__is_active = True
@@ -684,8 +715,15 @@ class OpenRecentlyClosedFileCommand(sublime_plugin.WindowCommand):
                 self.window.show_quick_panel(display_list, self.open_file, font_flag,
                                              on_highlight=self.show_preview,
                                              selected_index=selected_index)
-        else:
+
+        elif action == "open_latest_closed":
             self.open_file(0)
+        elif action == "delete_current_entry":
+            if not self.current_selected_index:
+                return
+            self.delete_current_entry()
+            self.set_refresh_in_progress()
+            sublime.active_window().run_command('hide_overlay')
 
     @classmethod
     def is_active(cls):
@@ -711,6 +749,7 @@ class OpenRecentlyClosedFileCommand(sublime_plugin.WindowCommand):
 
     def show_preview(self, selected_index):
         # Note: This function will never be called in ST2
+        self.current_selected_index = selected_index
         selected_entry = self.get_history_by_index(selected_index)
         if selected_entry:
             # A bug in SublimeText will cause the quick-panel to unexpectedly close trying to show the preview
@@ -718,7 +757,7 @@ class OpenRecentlyClosedFileCommand(sublime_plugin.WindowCommand):
             if self.get_view_from_another_group(selected_entry):
                 pass
             else:
-                FileHistory().preview_history(self.window, selected_index, selected_entry)
+                FileHistory().preview_history(self.window, selected_entry)
 
     def open_file(self, selected_index):
         self.__class__.__is_active = False
@@ -735,12 +774,12 @@ class OpenRecentlyClosedFileCommand(sublime_plugin.WindowCommand):
             # The user cancelled the action
             FileHistory().reset(self.window)
 
-        self.history_list = {}
-
-        if self.refresh_in_progress:
-            self.refresh_in_progress = False
+        if self.is_refresh_in_progress():
             args = {'current_project_only': self.current_project_only}
             sublime.active_window().run_command('open_recently_closed_file', args=args)
+        else:
+            self.history_list = {}
+            self.current_selected_index = None
 
 
 class OpenRecentlyCloseFileCommandContextHandler(sublime_plugin.EventListener):


### PR DESCRIPTION
There were a number of issues that I've tried to address in this PR.

1. When previews are disabled, the `quick_open_file_history` command was broken. This was because when the highlighted file is opened, the history list changes, and the quick panel becomes out of sync with the history list. If I try to quick-open another file in the list, the wrong file is opened. I've changed the quick panel to use a copy of the history list to address this.
2. `delete_file_history_entry` was broken in a number of ways. Please see the commits to see an explanation of the issues.

What I haven't fixed:

1. If previews are enabled, when a history entry is opened (quick or otherwise), the history list is not correctly updated to move the entry from `closed` to `open`. This is because when the view is created, it is transient, and transient views are ignored for history updates. But when the file is actually opened, Sublime does not seem to send another `on_load` event, so the history is never updated.