### PR TITLE
option for filename absolute path to avoid symlink redundancies

### DIFF
--- a/FileHistory.sublime-settings
+++ b/FileHistory.sublime-settings
@@ -62,6 +62,9 @@
     // Should the history file be nicely formatted?
     "prettify_history": false,
 
+    // Use the absolute path, so as to avoid symlink redundancies
+    "use_absolute_path": false,
+
     // List of path regexs to exclude from the history tracking.
     // Can be extended in project settings (in a "file_histoy" dict).
     //

--- a/FileHistory.sublime-settings
+++ b/FileHistory.sublime-settings
@@ -62,8 +62,8 @@
     // Should the history file be nicely formatted?
     "prettify_history": false,
 
-    // Use the absolute path, so as to avoid symlink redundancies
-    "use_absolute_path": false,
+    // Use the real path, so as to avoid symlink redundancies
+    "real_path": false,
 
     // List of path regexs to exclude from the history tracking.
     // Can be extended in project settings (in a "file_histoy" dict).
@@ -90,5 +90,5 @@
     "max_backup_count": 3,
 
     // Print out debug text?
-    "debug": false
+    "debug": false,
 }

--- a/file_history.py
+++ b/file_history.py
@@ -1,6 +1,7 @@
 import os
 import hashlib
 import json
+import os
 import time
 import re
 import shutil
@@ -82,6 +83,7 @@ class FileHistory(with_metaclass(Singleton)):
         self.HISTORY_FILE = os.path.normpath(os.path.join(sublime.packages_path(), history_path))
 
         self.USE_MONOSPACE = self.__ensure_setting('monospace_font', False)
+        self.USE_ABSOLUTE_PATH = self.__ensure_setting('absolute_path', False)
 
         self.TIMESTAMP_SHOW = self.__ensure_setting('timestamp_show', True)
         self.TIMESTAMP_FORMAT = self.__ensure_setting('timestamp_format', self.DEFAULT_TIMESTAMP_FORMAT)
@@ -316,8 +318,11 @@ class FileHistory(with_metaclass(Singleton)):
         if self.is_transient_view(window, view):
             return
 
+        if self.USE_ABSOLUTE_PATH:
+            filename = os.path.abspath(view.file_name())
+        else:
+            filename = view.file_name()
         # Only keep track of files that have a filename
-        filename = view.file_name()
         if filename is not None:
             project_name = self.get_current_project_key()
 

--- a/file_history.py
+++ b/file_history.py
@@ -318,17 +318,16 @@ class FileHistory(with_metaclass(Singleton)):
         if self.is_transient_view(window, view):
             return
 
-        self.debug('1 view.file_name() = %s' %view.file_name())
-        if self.REAL_PATH:
-            self.debug('self.REAL_PATH == True')
-            filename = os.path.realpath(view.file_name())
-        else:
-            filename = view.file_name()
-        self.debug('2 filename = %s' %filename)
+        filename = view.file_name()
         # Only keep track of files that have a filename
         if filename is not None:
+            if self.REAL_PATH:
+                realname = os.path.realpath(view.file_name())
+                if realname != filename:
+                    self.debug("Resolved '%s' to '%s'" % (filename, realname))
+                    filename = realname
+            
             project_name = self.get_current_project_key()
-
             if self.is_suppressed(view, filename):
                 # If filename matches 'path_exclude_patterns' then abort the history tracking
                 # and remove any references to this file from the history

--- a/file_history.py
+++ b/file_history.py
@@ -83,7 +83,7 @@ class FileHistory(with_metaclass(Singleton)):
         self.HISTORY_FILE = os.path.normpath(os.path.join(sublime.packages_path(), history_path))
 
         self.USE_MONOSPACE = self.__ensure_setting('monospace_font', False)
-        self.USE_ABSOLUTE_PATH = self.__ensure_setting('absolute_path', False)
+        self.REAL_PATH = self.__ensure_setting('real_path', False)
 
         self.TIMESTAMP_SHOW = self.__ensure_setting('timestamp_show', True)
         self.TIMESTAMP_FORMAT = self.__ensure_setting('timestamp_format', self.DEFAULT_TIMESTAMP_FORMAT)
@@ -318,10 +318,13 @@ class FileHistory(with_metaclass(Singleton)):
         if self.is_transient_view(window, view):
             return
 
-        if self.USE_ABSOLUTE_PATH:
-            filename = os.path.abspath(view.file_name())
+        self.debug('1 view.file_name() = %s' %view.file_name())
+        if self.REAL_PATH:
+            self.debug('self.REAL_PATH == True')
+            filename = os.path.realpath(view.file_name())
         else:
             filename = view.file_name()
+        self.debug('2 filename = %s' %filename)
         # Only keep track of files that have a filename
         if filename is not None:
             project_name = self.get_current_project_key()


### PR DESCRIPTION
Simple solution to issue #48 of having redundant entries because of symlinks. The limitation is that paths tend to be long in the UI, but I've found real paths will get in there at some point anyway.

A more sophisticated means of using the shortest version of a path relative to a real path would require a bit more work and better understanding of the extant code.